### PR TITLE
:arrow_up: Upgrade Node.js to supported version (v8.10)

### DIFF
--- a/cloudformation/lambda-manage-lifecycles.yaml
+++ b/cloudformation/lambda-manage-lifecycles.yaml
@@ -130,7 +130,7 @@ Resources:
       # KmsKeyArn: String
       MemorySize: 128
       Role: !GetAtt LambdaRole.Arn
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       Timeout: 300
       # TracingConfig:
       #   TracingConfig


### PR DESCRIPTION
Per email from AWS, Node 6.x is being deprecated. This PR upgrades Node to 8.10 in the CF template.

Note: reviewed code in `/lamba.js` reviewed for breaking changes and none found (ref: https://github.com/nodejs/wiki-archive/blob/master/Breaking-changes-between-v6-LTS-and-v8-LTS.md).